### PR TITLE
Add 6-axis, save bias values, and something else...

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,9 @@
         "vector": "cpp",
         "string_view": "cpp",
         "initializer_list": "cpp",
-        "ranges": "cpp"
+        "ranges": "cpp",
+        "*.tcc": "cpp",
+        "memory": "cpp",
+        "random": "cpp"
     }
 }

--- a/lib/ICM20948/ICM_20948.cpp
+++ b/lib/ICM20948/ICM_20948.cpp
@@ -1458,8 +1458,8 @@ ICM_20948_Status_e ICM_20948::initializeDMP(void)
   // Set gyro sample rate divider with GYRO_SMPLRT_DIV
   // Set accel sample rate divider with ACCEL_SMPLRT_DIV_2
   ICM_20948_smplrt_t mySmplrt;
-  mySmplrt.g = 19; // ODR is computed as follows: 1.1 kHz/(1+GYRO_SMPLRT_DIV[7:0]). 19 = 55Hz. InvenSense Nucleo example uses 19 (0x13).
-  mySmplrt.a = 19; // ODR is computed as follows: 1.125 kHz/(1+ACCEL_SMPLRT_DIV[11:0]). 19 = 56.25Hz. InvenSense Nucleo example uses 19 (0x13).
+  mySmplrt.g = 8; // ODR is computed as follows: 1.1 kHz/(1+GYRO_SMPLRT_DIV[7:0]). 19 = 55Hz. InvenSense Nucleo example uses 19 (0x13).
+  mySmplrt.a = 8; // ODR is computed as follows: 1.125 kHz/(1+ACCEL_SMPLRT_DIV[11:0]). 19 = 56.25Hz. InvenSense Nucleo example uses 19 (0x13).
   //mySmplrt.g = 4; // 225Hz
   //mySmplrt.a = 4; // 225Hz
   //mySmplrt.g = 8; // 112Hz
@@ -1534,7 +1534,7 @@ ICM_20948_Status_e ICM_20948::initializeDMP(void)
   //            0=1125Hz sample rate, 1=562.5Hz sample rate, ... 4=225Hz sample rate, ...
   //            10=102.2727Hz sample rate, ... etc.
   // @param[in] gyro_level 0=250 dps, 1=500 dps, 2=1000 dps, 3=2000 dps
-  result = setGyroSF(19, 3); if (result > worstResult) worstResult = result; // 19 = 55Hz (see above), 3 = 2000dps (see above)
+  result = setGyroSF(8, 3); if (result > worstResult) worstResult = result; // 19 = 55Hz (see above), 3 = 2000dps (see above)
 
   // Configure the Gyro full scale
   // 2000dps : 2^28
@@ -1545,21 +1545,21 @@ ICM_20948_Status_e ICM_20948::initializeDMP(void)
   result = writeDMPmems(GYRO_FULLSCALE, 4, &gyroFullScale[0]); if (result > worstResult) worstResult = result;
 
   // Configure the Accel Only Gain: 15252014 (225Hz) 30504029 (112Hz) 61117001 (56Hz)
-  const unsigned char accelOnlyGain[4] = {0x03, 0xA4, 0x92, 0x49}; // 56Hz
+  // const unsigned char accelOnlyGain[4] = {0x03, 0xA4, 0x92, 0x49}; // 56Hz
   //const unsigned char accelOnlyGain[4] = {0x00, 0xE8, 0xBA, 0x2E}; // 225Hz
-  //const unsigned char accelOnlyGain[4] = {0x01, 0xD1, 0x74, 0x5D}; // 112Hz
+  const unsigned char accelOnlyGain[4] = {0x01, 0xD1, 0x74, 0x5D}; // 112Hz
   result = writeDMPmems(ACCEL_ONLY_GAIN, 4, &accelOnlyGain[0]); if (result > worstResult) worstResult = result;
 
   // Configure the Accel Alpha Var: 1026019965 (225Hz) 977872018 (112Hz) 882002213 (56Hz)
-  const unsigned char accelAlphaVar[4] = {0x34, 0x92, 0x49, 0x25}; // 56Hz
+  // const unsigned char accelAlphaVar[4] = {0x34, 0x92, 0x49, 0x25}; // 56Hz
   //const unsigned char accelAlphaVar[4] = {0x3D, 0x27, 0xD2, 0x7D}; // 225Hz
-  //const unsigned char accelAlphaVar[4] = {0x3A, 0x49, 0x24, 0x92}; // 112Hz
+  const unsigned char accelAlphaVar[4] = {0x3A, 0x49, 0x24, 0x92}; // 112Hz
   result = writeDMPmems(ACCEL_ALPHA_VAR, 4, &accelAlphaVar[0]); if (result > worstResult) worstResult = result;
 
   // Configure the Accel A Var: 47721859 (225Hz) 95869806 (112Hz) 191739611 (56Hz)
-  const unsigned char accelAVar[4] = {0x0B, 0x6D, 0xB6, 0xDB}; // 56Hz
+  // const unsigned char accelAVar[4] = {0x0B, 0x6D, 0xB6, 0xDB}; // 56Hz
   //const unsigned char accelAVar[4] = {0x02, 0xD8, 0x2D, 0x83}; // 225Hz
-  //const unsigned char accelAVar[4] = {0x05, 0xB6, 0xDB, 0x6E}; // 112Hz
+  const unsigned char accelAVar[4] = {0x05, 0xB6, 0xDB, 0x6E}; // 112Hz
   result = writeDMPmems(ACCEL_A_VAR, 4, &accelAVar[0]); if (result > worstResult) worstResult = result;
 
   // Configure the Accel Cal Rate
@@ -1585,30 +1585,31 @@ ICM_20948_I2C::ICM_20948_I2C()
 {
 }
 
-ICM_20948_Status_e ICM_20948_I2C::begin(TwoWire &wirePort, bool ad0val, uint8_t ad0pin)
+ICM_20948_Status_e ICM_20948_I2C::begin(TwoWire &wirePort, uint8_t addr)
 {
   // Associate
-  _ad0 = ad0pin;
+  // _ad0 = ad0pin;
   _i2c = &wirePort;
-  _ad0val = ad0val;
+  // _ad0val = ad0val;
+  _addr = addr;
 
-  _addr = ICM_20948_I2C_ADDR_AD0;
-  if (_ad0val)
-  {
-    _addr = ICM_20948_I2C_ADDR_AD1;
-  }
+  // _addr = ICM_20948_I2C_ADDR_AD0;
+  // if (_ad0val)
+  // {
+  //   _addr = ICM_20948_I2C_ADDR_AD1;
+  // }
 
-  // Set pinmodes
-  if (_ad0 != ICM_20948_ARD_UNUSED_PIN)
-  {
-    pinMode(_ad0, OUTPUT);
-  }
+  // // Set pinmodes
+  // if (_ad0 != ICM_20948_ARD_UNUSED_PIN)
+  // {
+  //   pinMode(_ad0, OUTPUT);
+  // }
 
-  // Set pins to default positions
-  if (_ad0 != ICM_20948_ARD_UNUSED_PIN)
-  {
-    digitalWrite(_ad0, _ad0val);
-  }
+  // // Set pins to default positions
+  // if (_ad0 != ICM_20948_ARD_UNUSED_PIN)
+  // {
+  //   digitalWrite(_ad0, _ad0val);
+  // }
 
   // _i2c->begin(); // Moved into user's sketch
 

--- a/lib/ICM20948/ICM_20948.cpp
+++ b/lib/ICM20948/ICM_20948.cpp
@@ -1585,14 +1585,14 @@ ICM_20948_I2C::ICM_20948_I2C()
 {
 }
 
-ICM_20948_Status_e ICM_20948_I2C::begin(TwoWire &wirePort, uint8_t addr)
+ICM_20948_Status_e ICM_20948_I2C::begin(TwoWire &wirePort, bool ad0val, uint8_t ad0pin)
 {
   // Associate
   // _ad0 = ad0pin;
   _i2c = &wirePort;
   // _ad0val = ad0val;
-  _addr = addr;
-
+  _addr = ad0pin;
+  // Here ICM_20948_I2C_ADDR_AD0 is 0x68, But the AD0 of a single ICM may not be 0x68..?
   // _addr = ICM_20948_I2C_ADDR_AD0;
   // if (_ad0val)
   // {

--- a/lib/ICM20948/ICM_20948.h
+++ b/lib/ICM20948/ICM_20948.h
@@ -256,7 +256,7 @@ public:
 
   ICM_20948_I2C(); // Constructor
 
-  virtual ICM_20948_Status_e begin(TwoWire &wirePort = Wire, bool ad0val = true, uint8_t ad0pin = ICM_20948_ARD_UNUSED_PIN);
+  virtual ICM_20948_Status_e begin(TwoWire &wirePort = Wire, uint8_t addr = ICM_20948_ARD_UNUSED_PIN);
 };
 
 // SPI

--- a/lib/ICM20948/ICM_20948.h
+++ b/lib/ICM20948/ICM_20948.h
@@ -256,7 +256,7 @@ public:
 
   ICM_20948_I2C(); // Constructor
 
-  virtual ICM_20948_Status_e begin(TwoWire &wirePort = Wire, uint8_t addr = ICM_20948_ARD_UNUSED_PIN);
+  virtual ICM_20948_Status_e begin(TwoWire &wirePort = Wire, bool ad0val = true, uint8_t ad0pin = ICM_20948_ARD_UNUSED_PIN);
 };
 
 // SPI

--- a/lib/ICM20948/arduino-timer.h
+++ b/lib/ICM20948/arduino-timer.h
@@ -1,0 +1,275 @@
+/**
+   arduino-timer - library for delaying function calls
+
+   Copyright (c) 2018, Michael Contreras
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+   1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+   IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+   TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _CM_ARDUINO_TIMER_H__
+#define _CM_ARDUINO_TIMER_H__
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <Arduino.h>
+#else
+#include <WProgram.h>
+#endif
+
+#ifndef TIMER_MAX_TASKS
+    #define TIMER_MAX_TASKS 0x10
+#endif
+
+#define _timer_foreach_task(T, task) \
+    for (T task = tasks; task < tasks + max_tasks; ++task)
+
+#define timer_foreach_task(T) \
+    _timer_foreach_task(struct task *, T)
+
+#define timer_foreach_const_task(T) \
+    _timer_foreach_task(const struct task *, T)
+
+template <
+    size_t max_tasks = TIMER_MAX_TASKS, /* max allocated tasks */
+    unsigned long (*time_func)() = millis, /* time function for timer */
+    typename T = void * /* handler argument type */
+>
+class Timer {
+  public:
+
+    typedef uintptr_t Task; /* public task handle */
+    typedef bool (*handler_t)(T opaque); /* task handler func signature */
+
+    /* Calls handler with opaque as argument in delay units of time */
+    Task
+    in(unsigned long delay, handler_t h, T opaque = T())
+    {
+        return task_id(add_task(time_func(), delay, h, opaque));
+    }
+
+    /* Calls handler with opaque as argument at time */
+    Task
+    at(unsigned long time, handler_t h, T opaque = T())
+    {
+        const unsigned long now = time_func();
+        return task_id(add_task(now, time - now, h, opaque));
+    }
+
+    /* Calls handler with opaque as argument every interval units of time */
+    Task
+    every(unsigned long interval, handler_t h, T opaque = T())
+    {
+        return task_id(add_task(time_func(), interval, h, opaque, interval));
+    }
+
+    /* Cancel the timer task */
+    void
+    cancel(Task &task)
+    {
+        if (!task) return;
+
+        timer_foreach_task(t) {
+            if (t->handler && (t->id ^ task) == (uintptr_t)t) {
+                remove(t);
+                break;
+            }
+        }
+
+        task = (Task)NULL;
+    }
+
+    /* Cancel all timer tasks */
+    void
+    cancel()
+    {
+        timer_foreach_task(t) {
+            remove(t);
+        }
+    }
+
+    /* Ticks the timer forward - call this function in loop() */
+    unsigned long
+    tick()
+    {
+        tick<void>();
+        return ticks();
+    }
+
+    template <typename R> void
+    tick()
+    {
+        timer_foreach_task(task) {
+            if (task->handler) {
+                const unsigned long t = time_func();
+                const unsigned long duration = t - task->start;
+
+                if (duration >= task->expires) {
+                    task->repeat = task->handler(task->opaque) && task->repeat;
+
+                    if (task->repeat) task->start = t;
+                    else remove(task);
+                }
+            }
+        }
+    }
+
+    /* Ticks until the next event */
+    unsigned long
+    ticks() const
+    {
+        unsigned long ticks = (unsigned long)-1, elapsed;
+        const unsigned long start = time_func();
+
+        timer_foreach_const_task(task) {
+            if (task->handler) {
+                const unsigned long t = time_func();
+                const unsigned long duration = t - task->start;
+
+                if (duration >= task->expires) {
+                    ticks = 0;
+                    break;
+                } else {
+                    const unsigned long remaining = task->expires - duration;
+                    ticks = remaining < ticks ? remaining : ticks;
+                }
+            }
+        }
+
+        elapsed = time_func() - start;
+
+        if (elapsed >= ticks || ticks == (unsigned long)-1) ticks = 0;
+        else ticks -= elapsed;
+
+        return ticks;
+    }
+
+    /* Number of active tasks in the timer */
+    size_t
+    size() const
+    {
+        size_t s = 0;
+
+        timer_foreach_const_task(task) {
+            if (task->handler) ++s;
+        }
+
+        return s;
+    }
+
+    /* True if there are no active tasks */
+    bool
+    empty() const
+    {
+        timer_foreach_const_task(task) {
+            if (task->handler) return false;
+        }
+
+        return true;
+    }
+
+    Timer() : ctr(0), tasks{} {}
+
+  private:
+
+    size_t ctr;
+
+    struct task {
+        handler_t handler; /* task handler callback func */
+        T opaque; /* argument given to the callback handler */
+        unsigned long start,
+                      expires; /* when the task expires */
+        size_t repeat, /* repeat task */
+               id;
+    } tasks[max_tasks];
+
+    inline
+    void
+    remove(struct task *task)
+    {
+        task->handler = NULL;
+        task->opaque = T();
+        task->start = 0;
+        task->expires = 0;
+        task->repeat = 0;
+        task->id = 0;
+    }
+
+    inline
+    Task
+    task_id(const struct task * const t)
+    {
+        const Task id = (Task)t;
+
+        return id ? id ^ t->id : id;
+    }
+
+    inline
+    struct task *
+    next_task_slot()
+    {
+        timer_foreach_task(slot) {
+            if (slot->handler == NULL) return slot;
+        }
+
+        return NULL;
+    }
+
+    inline
+    struct task *
+    add_task(unsigned long start, unsigned long expires,
+             handler_t h, T opaque, bool repeat = 0)
+    {
+        struct task * const slot = next_task_slot();
+
+        if (!slot) return NULL;
+
+        if (++ctr == 0) ++ctr; // overflow
+
+        slot->id = ctr;
+        slot->handler = h;
+        slot->opaque = opaque;
+        slot->start = start;
+        slot->expires = expires;
+        slot->repeat = repeat;
+
+        return slot;
+    }
+};
+
+/* create a timer with the default settings */
+inline Timer<>
+timer_create_default()
+{
+    return Timer<>();
+}
+
+#undef _timer_foreach_task
+#undef timer_foreach_task
+#undef timer_foreach_const_task
+
+#endif

--- a/src/defines.h
+++ b/src/defines.h
@@ -80,7 +80,7 @@
   #define IMU_HAS_ACCELL true
   #define IMU_HAS_GYRO true
   #define IMU_HAS_MAG true
-  #define USE_6_AXIS false // uses 9 (with mag) if false
+  #define USE_6_AXIS true // uses 9 (with mag) if false
   #define LOAD_BIAS 1 // Loads the bias values from NVS on start (ESP32 Only)
   #define SAVE_BIAS 1 // Periodically saves bias calibration data to NVS (ESP32 Only)
   #define ENABLE_TAP false // monitor accel for (tripple) tap events and send them. Uses more cpu, disable if problems. Server does nothing with value so disabled atm

--- a/src/defines.h
+++ b/src/defines.h
@@ -80,7 +80,7 @@
   #define IMU_HAS_ACCELL true
   #define IMU_HAS_GYRO true
   #define IMU_HAS_MAG true
-  #define USE_6_AXIS true // uses 9 (with mag) if false
+  #define USE_6_AXIS false // uses 9 (with mag) if false
   #define LOAD_BIAS 1 // Loads the bias values from NVS on start (ESP32 Only)
   #define SAVE_BIAS 1 // Periodically saves bias calibration data to NVS (ESP32 Only)
   #define ENABLE_TAP false // monitor accel for (tripple) tap events and send them. Uses more cpu, disable if problems. Server does nothing with value so disabled atm
@@ -88,14 +88,6 @@
   #define ICM_ADDR_2 0x68
   #define I2C_SPEED 400000
   #define SECOND_IMU true
-  #ifdef IMU_ROTATION // to not interfere with master repo
-    #undef IMU_ROTATION
-  #endif
-  #ifdef SECOND_IMU_ROTATION
-    #undef SECOND_IMU_ROTATION
-  #endif
-  #define IMU_ROTATION PI
-  #define SECOND_IMU_ROTATION IMU_ROTATION  
 #else
     #error Select IMU in defines.h
 #endif

--- a/src/icm20948sensor.cpp
+++ b/src/icm20948sensor.cpp
@@ -84,7 +84,7 @@ void ICM20948Sensor::save_bias(bool repeat) {
 
         EEPROM.begin(4096); // max memory usage = 4096
         EEPROM.get(addr + 100, count); // 1st imu counter in EEPROM addr: 0x69+100=205, 2nd addr: 0x68+100=204
-        Serial.printf("[0x%02X] EEPROM ICM: %d, position: %d, getcount: %d \n", addr, (int)auxiliary, addr + 100, count);
+        Serial.printf("[0x%02X] EEPROM position: %d, count: %d \n", addr, addr + 100, count);
         if (count < 0 || count > 42) {
             count = (int)auxiliary; // 1st imu counter is even number, 2nd is odd
         } else if (repeat) {
@@ -134,7 +134,7 @@ void ICM20948Sensor::motionSetup() {
     #ifdef FULL_DEBUG
         imu.enableDebugging(Serial);
     #endif
-    if (imu.begin(Wire, ((int)auxiliary == 0 ? first_imu : second_imu)) != ICM_20948_Stat_Ok) {
+    if (imu.begin(Wire, 0, ((int)auxiliary == 0 ? first_imu : second_imu)) != ICM_20948_Stat_Ok) {
         Serial.print("[ERR] IMU ICM20948: Can't connect to ");
         Serial.println(IMU_NAME);
         signalAssert();
@@ -188,72 +188,72 @@ void ICM20948Sensor::motionSetup() {
         }
     }
 
-    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_ROTATION_VECTOR) == ICM_20948_Stat_Ok)
-    {
-        Serial.print("Enabled DMP Senor for Sensor Rotation Vector");
-        Serial.println(IMU_NAME);
-    }
-    else
-    {
-        Serial.print("[ERR] Enabling DMP Senor for Sensor Rotation Vector Failed");
-        Serial.println(IMU_NAME);
-        return; 
-    }
-    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_LINEAR_ACCELERATION) == ICM_20948_Stat_Ok)
-    {
-        Serial.print("Enabled DMP Senor for LINEAR ACCELERATION Vector");
-        Serial.println(IMU_NAME);
-    }
-    else
-    {
-        Serial.print("[ERR] Enabling DMP Senor for LINEAR ACCELERATION Failed");
-        Serial.println(IMU_NAME);
-        return; 
-    }
-    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_GRAVITY) == ICM_20948_Stat_Ok)
-    {
-        Serial.print("Enabled DMP Senor for GRAVITY Vector");
-        Serial.println(IMU_NAME);
-    }
-    else
-    {
-        Serial.print("[ERR] Enabling DMP Senor for GRAVITY Failed");
-        Serial.println(IMU_NAME);
-        return; 
-    }
-    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_RAW_GYROSCOPE) == ICM_20948_Stat_Ok)
-    {
-        Serial.print("Enabled DMP Senor for Raw Gyro");
-        Serial.println(IMU_NAME);
-    }
-    else
-    {
-        Serial.print("[ERR] Enabling DMP Senor for Raw Gyro Failed");
-        Serial.println(IMU_NAME);
-        return;
-    }
-    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_RAW_ACCELEROMETER) == ICM_20948_Stat_Ok)
-    {
-        Serial.print("Enabled DMP Senor for Raw Acc");
-        Serial.println(IMU_NAME);
-    }
-    else
-    {
-        Serial.print("[ERR] Enabling DMP Senor for Raw Acc Failed");
-        Serial.println(IMU_NAME);
-        return;
-    }
-    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_MAGNETIC_FIELD_UNCALIBRATED) == ICM_20948_Stat_Ok)
-    {
-        Serial.print("Enabled DMP Senor for Magnetic Field Uncalibrated");
-        Serial.println(IMU_NAME);
-    }
-    else
-    {
-        Serial.print("[ERR] Enabling DMP Senor for Magnetic Field Uncalibrated Failed");
-        Serial.println(IMU_NAME);
-        return;
-    }
+    // if(imu.enableDMPSensor(INV_ICM20948_SENSOR_ROTATION_VECTOR) == ICM_20948_Stat_Ok)
+    // {
+    //     Serial.print("Enabled DMP Senor for Sensor Rotation Vector");
+    //     Serial.println(IMU_NAME);
+    // }
+    // else
+    // {
+    //     Serial.print("[ERR] Enabling DMP Senor for Sensor Rotation Vector Failed");
+    //     Serial.println(IMU_NAME);
+    //     return; 
+    // }
+    // if(imu.enableDMPSensor(INV_ICM20948_SENSOR_LINEAR_ACCELERATION) == ICM_20948_Stat_Ok)
+    // {
+    //     Serial.print("Enabled DMP Senor for LINEAR ACCELERATION Vector");
+    //     Serial.println(IMU_NAME);
+    // }
+    // else
+    // {
+    //     Serial.print("[ERR] Enabling DMP Senor for LINEAR ACCELERATION Failed");
+    //     Serial.println(IMU_NAME);
+    //     return; 
+    // }
+    // if(imu.enableDMPSensor(INV_ICM20948_SENSOR_GRAVITY) == ICM_20948_Stat_Ok)
+    // {
+    //     Serial.print("Enabled DMP Senor for GRAVITY Vector");
+    //     Serial.println(IMU_NAME);
+    // }
+    // else
+    // {
+    //     Serial.print("[ERR] Enabling DMP Senor for GRAVITY Failed");
+    //     Serial.println(IMU_NAME);
+    //     return; 
+    // }
+    // if(imu.enableDMPSensor(INV_ICM20948_SENSOR_RAW_GYROSCOPE) == ICM_20948_Stat_Ok)
+    // {
+    //     Serial.print("Enabled DMP Senor for Raw Gyro");
+    //     Serial.println(IMU_NAME);
+    // }
+    // else
+    // {
+    //     Serial.print("[ERR] Enabling DMP Senor for Raw Gyro Failed");
+    //     Serial.println(IMU_NAME);
+    //     return;
+    // }
+    // if(imu.enableDMPSensor(INV_ICM20948_SENSOR_RAW_ACCELEROMETER) == ICM_20948_Stat_Ok)
+    // {
+    //     Serial.print("Enabled DMP Senor for Raw Acc");
+    //     Serial.println(IMU_NAME);
+    // }
+    // else
+    // {
+    //     Serial.print("[ERR] Enabling DMP Senor for Raw Acc Failed");
+    //     Serial.println(IMU_NAME);
+    //     return;
+    // }
+    // if(imu.enableDMPSensor(INV_ICM20948_SENSOR_MAGNETIC_FIELD_UNCALIBRATED) == ICM_20948_Stat_Ok)
+    // {
+    //     Serial.print("Enabled DMP Senor for Magnetic Field Uncalibrated");
+    //     Serial.println(IMU_NAME);
+    // }
+    // else
+    // {
+    //     Serial.print("[ERR] Enabling DMP Senor for Magnetic Field Uncalibrated Failed");
+    //     Serial.println(IMU_NAME);
+    //     return;
+    // }
 
     // Will probally be needed later, when more features are needed
 
@@ -356,7 +356,7 @@ void ICM20948Sensor::motionSetup() {
         count = 0;
         EEPROM.begin(4096); // max memory usage = 4096
         EEPROM.get(addr + 100, count); // 1st imu counter in EEPROM addr: 0x69+100=205, 2nd addr: 0x68+100=204
-        Serial.printf("[0x%02X] EEPROM ICM: %d, position: %d, getcount: %d \n", addr, (int)auxiliary, addr + 100, count);
+        Serial.printf("[0x%02X] EEPROM position: %d, count: %d \n", addr, addr + 100, count);
         if (count < 0 || count > 42) {
             count = (int)auxiliary; // 1st imu counter is even number, 2nd is odd
             EEPROM.put(addr + 100, count);

--- a/src/icm20948sensor.cpp
+++ b/src/icm20948sensor.cpp
@@ -10,6 +10,7 @@ Based on Demo's fork
 #include "calibration.h"
 #include <i2cscan.h>
 #include "ledstatus.h"
+#include <EEPROM.h> // for 8266, save the current bias values to eeprom
 
 #define BIAS_DEBUG false
 
@@ -61,92 +62,56 @@ void ICM20948Sensor::i2c_scan() { // Basically obsolete but kept for when adding
 }
 
 void ICM20948Sensor::save_bias(bool repeat) { 
-#if defined(SAVE_BIAS)
-  if (SAVE_BIAS) 
-  {
-    int bias_a[3], bias_g[3], bias_m[3];
-    
-    imu.GetBiasGyroX(&bias_g[0]);
-    imu.GetBiasGyroY(&bias_g[1]);
-    imu.GetBiasGyroZ(&bias_g[2]);
+    #if defined(SAVE_BIAS) && SAVE_BIAS && ESP8266
+        int8_t count;
+        int32_t bias_a[3], bias_g[3], bias_m[3];
 
-    Serial.print("Starting Gyro Bias is ");
-    Serial.print(bias_g[0]);
-    Serial.print(",");
-    Serial.print(bias_g[1]);
-    Serial.print(",");
-    Serial.println(bias_g[2]);
+        imu.GetBiasGyroX(&bias_g[0]);
+        imu.GetBiasGyroY(&bias_g[1]);
+        imu.GetBiasGyroZ(&bias_g[2]);
 
+        imu.GetBiasAccelX(&bias_a[0]);
+        imu.GetBiasAccelY(&bias_a[1]);
+        imu.GetBiasAccelZ(&bias_a[2]);
 
-    imu.GetBiasAccelX(&bias_a[0]);
-    imu.GetBiasAccelY(&bias_a[1]);
-    imu.GetBiasAccelZ(&bias_a[2]);
+        imu.GetBiasCPassX(&bias_m[0]);
+        imu.GetBiasCPassY(&bias_m[1]);
+        imu.GetBiasCPassZ(&bias_m[2]);
 
-    Serial.print("Starting Accel Bias is ");
-    Serial.print(bias_a[0]);
-    Serial.print(",");
-    Serial.print(bias_a[1]);
-    Serial.print(",");
-    Serial.println(bias_a[2]);
+        bool gyro_set  = bias_g[0] && bias_g[1] && bias_g[2];
+        bool accel_set = bias_a[0] && bias_a[1] && bias_a[2];
+        bool CPass_set = bias_m[0] && bias_m[1] && bias_m[2];
 
-    imu.GetBiasCPassX(&bias_m[0]);
-    imu.GetBiasCPassY(&bias_m[1]);
-    imu.GetBiasCPassZ(&bias_m[2]);
-
-    Serial.print("Starting CPass Bias is ");
-    Serial.print(bias_m[0]);
-    Serial.print(",");
-    Serial.print(bias_m[1]);
-    Serial.print(",");
-    Serial.println(bias_m[2]);
-
-    // bool accel_set = bias_a[0] && bias_a[1] && bias_a[2];
-    // bool gyro_set = bias_g[0] && bias_g[1] && bias_g[2];
-    // bool mag_set = bias_m[0] && bias_m[1] && bias_m[2];
-    
-    // if (accel_set) {
-    //   // Save accel
-    //   prefs.putInt(auxiliary ? "ba01" : "ba00", bias_a[0]);
-    //   prefs.putInt(auxiliary ? "ba11" : "ba10", bias_a[1]);
-    //   prefs.putInt(auxiliary ? "ba21" : "ba20", bias_a[2]);
-
-    // #ifdef FULL_DEBUG
-    //         Serial.println("Wrote Accel Bias");
-    // #endif
-    // }
-    
-    // if (gyro_set) {
-    //   // Save gyro
-    //   prefs.putInt(auxiliary ? "bg01" : "bg00", bias_g[0]);
-    //   prefs.putInt(auxiliary ? "bg11" : "bg10", bias_g[1]);
-    //   prefs.putInt(auxiliary ? "bg21" : "bg20", bias_g[2]);
-
-    // #ifdef FULL_DEBUG
-    //     Serial.println("Wrote Gyro Bias");
-    // #endif
-    // }
-
-    // if (mag_set) {
-    //   // Save mag
-    //   prefs.putInt(auxiliary ? "bm01" : "bm00", bias_m[0]);
-    //   prefs.putInt(auxiliary ? "bm11" : "bm10", bias_m[1]);
-    //   prefs.putInt(auxiliary ? "bm21" : "bm20", bias_m[2]);
-
-    // #ifdef FULL_DEBUG
-    //     Serial.println("Wrote Mag Bias");
-    // #endif
-    // }    
-  }  
-
-    // if (repeat) {
-    //     bias_save_counter++;
-    //     // Possible: Could make it repeat the final timer value if any of the biases are still 0. Save strategy could be improved.
-    //     if (sizeof(bias_save_periods) != bias_save_counter)
-    //     {
-    //         timer.in(bias_save_periods[bias_save_counter] * 1000, [](void *arg) -> bool { ((ICM20948Sensor*)arg)->save_bias(true); return false; }, this);
-    //     }
-    // }
-#endif
+        EEPROM.begin(4096); // max memory usage = 4096
+        EEPROM.get(addr + 100, count); // 1st imu counter in EEPROM addr: 0x69+100=205, 2nd addr: 0x68+100=204
+        Serial.printf("[0x%02X] EEPROM ICM: %d, position: %d, getcount: %d \n", addr, (int)auxiliary, addr + 100, count);
+        if (count < 0 || count > 42) {
+            count = (int)auxiliary; // 1st imu counter is even number, 2nd is odd
+        } else if (repeat) {
+            count++;
+        }
+        EEPROM.put(addr + 100, count);
+        Serial.printf("[0x%02X] bias gyro  save(%d): [%d, %d, %d] \n", addr, count * 12, bias_g[0], bias_g[1], bias_g[2]);
+        Serial.printf("[0x%02X] bias accel save(%d): [%d, %d, %d] \n", addr, count * 12, bias_a[0], bias_a[1], bias_a[2]);
+        Serial.printf("[0x%02X] bias CPass save(%d): [%d, %d, %d] \n\n", addr, count * 12, bias_m[0], bias_m[1], bias_m[2]);
+        if (gyro_set) {
+            EEPROM.put(1024 + (count * 12), bias_g); // 1024 ~ 2008
+        }
+        if (accel_set) {
+            EEPROM.put(2046 + (count * 12), bias_a); // 2046 ~ 3030
+        }
+        if (CPass_set) {
+            EEPROM.put(3072 + (count * 12), bias_m); // 3072 ~ 4056
+        }
+        EEPROM.end(); // save and end
+        if (repeat) {
+            bias_save_counter++;
+            // Possible: Could make it repeat the final timer value if any of the biases are still 0. Save strategy could be improved.
+            if (sizeof(bias_save_periods) != bias_save_counter) {
+                timer.in(bias_save_periods[bias_save_counter] * 1000, [](void *arg) -> bool { ((ICM20948Sensor*)arg)->save_bias(true); return false; }, this);
+            }
+        }
+    #endif
 }
 
 void ICM20948Sensor::setupICM20948(bool auxiliary, uint8_t addr) {
@@ -156,16 +121,20 @@ void ICM20948Sensor::setupICM20948(bool auxiliary, uint8_t addr) {
     if(auxiliary)
     {
         Serial.println("2nd IMU setup");
+        second_imu = addr;
     }
     else
     {
         Serial.println("1st IMU setup");
+        first_imu = addr;
     }
 }
 
 void ICM20948Sensor::motionSetup() {
-
-    if (imu.begin(Wire, ad0_Val) != ICM_20948_Stat_Ok) {
+    #ifdef FULL_DEBUG
+        imu.enableDebugging(Serial);
+    #endif
+    if (imu.begin(Wire, ((int)auxiliary == 0 ? first_imu : second_imu)) != ICM_20948_Stat_Ok) {
         Serial.print("[ERR] IMU ICM20948: Can't connect to ");
         Serial.println(IMU_NAME);
         signalAssert();
@@ -173,9 +142,9 @@ void ICM20948Sensor::motionSetup() {
     }
 
     // Configure imu setup and load any stored bias values
-    poss_addresses[0] = addr;
-    i2c_scan();
-    Serial.println("Scan completed");
+    // poss_addresses[0] = addr;
+    // i2c_scan();
+    // Serial.println("Scan completed");
     if(imu.initializeDMP() == ICM_20948_Stat_Ok)
     {
         Serial.print("DMP initialized"); 
@@ -187,17 +156,36 @@ void ICM20948Sensor::motionSetup() {
         Serial.println(IMU_NAME);
         return;
     }
-    
-    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_ORIENTATION) == ICM_20948_Stat_Ok)
+
+    if (USE_6_AXIS)
     {
-        Serial.print("Enabled DMP Senor for Sensor Orientation");
-        Serial.println(IMU_NAME);
+        Serial.printf("[0x%02X] use 6-axis...\n", addr);
+        if(imu.enableDMPSensor(INV_ICM20948_SENSOR_GAME_ROTATION_VECTOR) == ICM_20948_Stat_Ok)
+        {
+            Serial.print("Enabled DMP Senor for Game Rotation Vector");
+            Serial.println(IMU_NAME);
+        }
+        else
+        {
+            Serial.println("[ERR] Enabling DMP Senor for Game Rotation Vector Failed");
+            Serial.println(IMU_NAME);
+            return; 
+        }
     }
     else
     {
-        Serial.print("[ERR] Enabling DMP Senor for Game Rotation Vector Failed");
-        Serial.println(IMU_NAME);
-        return; 
+        Serial.printf("[0x%02X] use 9-axis...\n", addr);
+        if(imu.enableDMPSensor(INV_ICM20948_SENSOR_ORIENTATION) == ICM_20948_Stat_Ok)
+        {
+            Serial.print("Enabled DMP Senor for Sensor Orientation");
+            Serial.println(IMU_NAME);
+        }
+        else
+        {
+            Serial.print("[ERR] Enabling DMP Senor Orientation Failed");
+            Serial.println(IMU_NAME);
+            return; 
+        }
     }
 
     if(imu.enableDMPSensor(INV_ICM20948_SENSOR_ROTATION_VECTOR) == ICM_20948_Stat_Ok)
@@ -211,7 +199,28 @@ void ICM20948Sensor::motionSetup() {
         Serial.println(IMU_NAME);
         return; 
     }
-
+    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_LINEAR_ACCELERATION) == ICM_20948_Stat_Ok)
+    {
+        Serial.print("Enabled DMP Senor for LINEAR ACCELERATION Vector");
+        Serial.println(IMU_NAME);
+    }
+    else
+    {
+        Serial.print("[ERR] Enabling DMP Senor for LINEAR ACCELERATION Failed");
+        Serial.println(IMU_NAME);
+        return; 
+    }
+    if(imu.enableDMPSensor(INV_ICM20948_SENSOR_GRAVITY) == ICM_20948_Stat_Ok)
+    {
+        Serial.print("Enabled DMP Senor for GRAVITY Vector");
+        Serial.println(IMU_NAME);
+    }
+    else
+    {
+        Serial.print("[ERR] Enabling DMP Senor for GRAVITY Failed");
+        Serial.println(IMU_NAME);
+        return; 
+    }
     if(imu.enableDMPSensor(INV_ICM20948_SENSOR_RAW_GYROSCOPE) == ICM_20948_Stat_Ok)
     {
         Serial.print("Enabled DMP Senor for Raw Gyro");
@@ -260,16 +269,33 @@ void ICM20948Sensor::motionSetup() {
     // if(imu.setDMPODRrate(DMP_ODR_Reg_Cpass, 54) == ICM_20948_Stat_Ok);        // Set to 1Hz
     // if(imu.setDMPODRrate(DMP_ODR_Reg_Cpass_Calibr, 54) == ICM_20948_Stat_Ok); // Set to 1Hz
 
-    if(imu.setDMPODRrate(DMP_ODR_Reg_Quat9, 0) == ICM_20948_Stat_Ok)
+    if (USE_6_AXIS)
     {
-        Serial.print("Set Quat9 to Max frequency");
-        Serial.println(IMU_NAME);
+        if(imu.setDMPODRrate(DMP_ODR_Reg_Quat6, 0) == ICM_20948_Stat_Ok)
+        {
+            Serial.print("Set Quat6 to Max frequency");
+            Serial.println(IMU_NAME);
+        }
+        else
+        {
+            Serial.print("[ERR] Failed to Set Quat6 to Max frequency");
+            Serial.println(IMU_NAME);
+            return;
+        }
     }
     else
     {
-        Serial.print("[ERR] Failed to Set Quat9 to Max frequency");
-        Serial.println(IMU_NAME);
-        return;
+        if(imu.setDMPODRrate(DMP_ODR_Reg_Quat9, 0) == ICM_20948_Stat_Ok)
+        {
+            Serial.print("Set Quat9 to Max frequency");
+            Serial.println(IMU_NAME);
+        }
+        else
+        {
+            Serial.print("[ERR] Failed to Set Quat9 to Max frequency");
+            Serial.println(IMU_NAME);
+            return;
+        }
     }
 
     // Enable the FIFO
@@ -324,53 +350,25 @@ void ICM20948Sensor::motionSetup() {
         return;
     }
 
-    if(BIAS_DEBUG)
-    {
-        int bias_a[3], bias_g[3], bias_m[3];
-        
-        imu.GetBiasGyroX(&bias_g[0]);
-        imu.GetBiasGyroY(&bias_g[1]);
-        imu.GetBiasGyroZ(&bias_g[2]);
+    #if defined(LOAD_BIAS) && LOAD_BIAS && ESP8266
+        int8_t count;
+        int32_t bias_g[3], bias_a[3], bias_m[3];
+        count = 0;
+        EEPROM.begin(4096); // max memory usage = 4096
+        EEPROM.get(addr + 100, count); // 1st imu counter in EEPROM addr: 0x69+100=205, 2nd addr: 0x68+100=204
+        Serial.printf("[0x%02X] EEPROM ICM: %d, position: %d, getcount: %d \n", addr, (int)auxiliary, addr + 100, count);
+        if (count < 0 || count > 42) {
+            count = (int)auxiliary; // 1st imu counter is even number, 2nd is odd
+            EEPROM.put(addr + 100, count);
+        }
+        EEPROM.get(1024 + (count * 12), bias_g); // 1024 ~ 2008
+        EEPROM.get(2046 + (count * 12), bias_a); // 2046 ~ 3030
+        EEPROM.get(3072 + (count * 12), bias_m); // 3072 ~ 4056
+        EEPROM.end();
+        Serial.printf("[0x%02X] EEPROM gyro  get(%d): [%d, %d, %d] \n", addr, count * 12, bias_g[0], bias_g[1], bias_g[2]);
+        Serial.printf("[0x%02X] EEPROM accel get(%d): [%d, %d, %d] \n", addr, count * 12, bias_a[0], bias_a[1], bias_a[2]);
+        Serial.printf("[0x%02X] EEPROM CPass get(%d): [%d, %d, %d] \n\n", addr, count * 12, bias_m[0], bias_m[1], bias_m[2]);
 
-        imu.GetBiasAccelX(&bias_a[0]);
-        imu.GetBiasAccelY(&bias_a[1]);
-        imu.GetBiasAccelZ(&bias_a[2]);
-
-        imu.GetBiasCPassX(&bias_m[0]);
-        imu.GetBiasCPassY(&bias_m[1]);
-        imu.GetBiasCPassZ(&bias_m[2]);
-
-        Serial.print("Starting Gyro Bias is ");
-        Serial.print(bias_g[0]);
-        Serial.print(",");
-        Serial.print(bias_g[1]);
-        Serial.print(",");
-        Serial.println(bias_g[2]);
-        Serial.print("Starting Accel Bias is ");
-        Serial.print(bias_a[0]);
-        Serial.print(",");
-        Serial.print(bias_a[1]);
-        Serial.print(",");
-        Serial.println(bias_a[2]);
-        Serial.print("Starting CPass Bias is ");
-        Serial.print(bias_m[0]);
-        Serial.print(",");
-        Serial.print(bias_m[1]);
-        Serial.print(",");
-        Serial.println(bias_m[2]);
-
-        //Sets all bias to 90
-        bias_g[0] = 90;
-        bias_g[1] = 90;
-        bias_g[2] = 90;
-        bias_a[0] = 90;
-        bias_a[1] = 90;
-        bias_a[2] = 90;
-        bias_m[0] = 90;
-        bias_m[1] = 90;
-        bias_m[2] = 90;
-
-        //Sets all bias to 0 in memory
         imu.SetBiasGyroX(bias_g[0]);
         imu.SetBiasGyroY(bias_g[1]);
         imu.SetBiasGyroZ(bias_g[2]);
@@ -382,68 +380,130 @@ void ICM20948Sensor::motionSetup() {
         imu.SetBiasCPassX(bias_m[0]);
         imu.SetBiasCPassY(bias_m[1]);
         imu.SetBiasCPassZ(bias_m[2]);
+    #else
+        if(BIAS_DEBUG)
+        {
+            int bias_a[3], bias_g[3], bias_m[3];
+            
+            imu.GetBiasGyroX(&bias_g[0]);
+            imu.GetBiasGyroY(&bias_g[1]);
+            imu.GetBiasGyroZ(&bias_g[2]);
 
-        //Sets all bias to 0
-        bias_g[0] = 0;
-        bias_g[1] = 0;
-        bias_g[2] = 0;
-        bias_a[0] = 0;
-        bias_a[1] = 0;
-        bias_a[2] = 0;
-        bias_m[0] = 0;
-        bias_m[1] = 0;
-        bias_m[2] = 0;
+            imu.GetBiasAccelX(&bias_a[0]);
+            imu.GetBiasAccelY(&bias_a[1]);
+            imu.GetBiasAccelZ(&bias_a[2]);
 
-        //Reloads all bias from memory
-        imu.GetBiasGyroX(&bias_g[0]);
-        imu.GetBiasGyroY(&bias_g[1]);
-        imu.GetBiasGyroZ(&bias_g[2]);
+            imu.GetBiasCPassX(&bias_m[0]);
+            imu.GetBiasCPassY(&bias_m[1]);
+            imu.GetBiasCPassZ(&bias_m[2]);
 
-        imu.GetBiasAccelX(&bias_a[0]);
-        imu.GetBiasAccelY(&bias_a[1]);
-        imu.GetBiasAccelZ(&bias_a[2]);
+            Serial.print("Starting Gyro Bias is ");
+            Serial.print(bias_g[0]);
+            Serial.print(",");
+            Serial.print(bias_g[1]);
+            Serial.print(",");
+            Serial.println(bias_g[2]);
+            Serial.print("Starting Accel Bias is ");
+            Serial.print(bias_a[0]);
+            Serial.print(",");
+            Serial.print(bias_a[1]);
+            Serial.print(",");
+            Serial.println(bias_a[2]);
+            Serial.print("Starting CPass Bias is ");
+            Serial.print(bias_m[0]);
+            Serial.print(",");
+            Serial.print(bias_m[1]);
+            Serial.print(",");
+            Serial.println(bias_m[2]);
 
-        imu.GetBiasCPassX(&bias_m[0]);
-        imu.GetBiasCPassY(&bias_m[1]);
-        imu.GetBiasCPassZ(&bias_m[2]);
+            //Sets all bias to 90
+            bias_g[0] = 90;
+            bias_g[1] = 90;
+            bias_g[2] = 90;
+            bias_a[0] = 90;
+            bias_a[1] = 90;
+            bias_a[2] = 90;
+            bias_m[0] = 90;
+            bias_m[1] = 90;
+            bias_m[2] = 90;
 
-        Serial.println("All set bias should be 90");
+            //Sets all bias to 0 in memory
+            imu.SetBiasGyroX(bias_g[0]);
+            imu.SetBiasGyroY(bias_g[1]);
+            imu.SetBiasGyroZ(bias_g[2]);
 
-        Serial.print("Set Gyro Bias is ");
-        Serial.print(bias_g[0]);
-        Serial.print(",");
-        Serial.print(bias_g[1]);
-        Serial.print(",");
-        Serial.println(bias_g[2]);
-        Serial.print("Set Accel Bias is ");
-        Serial.print(bias_a[0]);
-        Serial.print(",");
-        Serial.print(bias_a[1]);
-        Serial.print(",");
-        Serial.println(bias_a[2]);
-        Serial.print("Set CPass Bias is ");
-        Serial.print(bias_m[0]);
-        Serial.print(",");
-        Serial.print(bias_m[1]);
-        Serial.print(",");
-        Serial.println(bias_m[2]);
-    }
+            imu.SetBiasAccelX(bias_a[0]);
+            imu.SetBiasAccelY(bias_a[1]);
+            imu.SetBiasAccelZ(bias_a[2]);
 
+            imu.SetBiasCPassX(bias_m[0]);
+            imu.SetBiasCPassY(bias_m[1]);
+            imu.SetBiasCPassZ(bias_m[2]);
 
+            //Sets all bias to 0
+            bias_g[0] = 0;
+            bias_g[1] = 0;
+            bias_g[2] = 0;
+            bias_a[0] = 0;
+            bias_a[1] = 0;
+            bias_a[2] = 0;
+            bias_m[0] = 0;
+            bias_m[1] = 0;
+            bias_m[2] = 0;
+
+            //Reloads all bias from memory
+            imu.GetBiasGyroX(&bias_g[0]);
+            imu.GetBiasGyroY(&bias_g[1]);
+            imu.GetBiasGyroZ(&bias_g[2]);
+
+            imu.GetBiasAccelX(&bias_a[0]);
+            imu.GetBiasAccelY(&bias_a[1]);
+            imu.GetBiasAccelZ(&bias_a[2]);
+
+            imu.GetBiasCPassX(&bias_m[0]);
+            imu.GetBiasCPassY(&bias_m[1]);
+            imu.GetBiasCPassZ(&bias_m[2]);
+
+            Serial.println("All set bias should be 90");
+
+            Serial.print("Set Gyro Bias is ");
+            Serial.print(bias_g[0]);
+            Serial.print(",");
+            Serial.print(bias_g[1]);
+            Serial.print(",");
+            Serial.println(bias_g[2]);
+            Serial.print("Set Accel Bias is ");
+            Serial.print(bias_a[0]);
+            Serial.print(",");
+            Serial.print(bias_a[1]);
+            Serial.print(",");
+            Serial.println(bias_a[2]);
+            Serial.print("Set CPass Bias is ");
+            Serial.print(bias_m[0]);
+            Serial.print(",");
+            Serial.print(bias_m[1]);
+            Serial.print(",");
+            Serial.println(bias_m[2]);
+        }
+    #endif
 
     lastData = millis();
     working = true;
+
+    #if ESP8266 && defined(SAVE_BIAS)
+        timer.in(bias_save_periods[0] * 1000, [](void *arg) -> bool { ((ICM20948Sensor*)arg)->save_bias(true); return false; }, this);
+    #endif
 }
 
 
 //I don't think there is any need for a motionloop with the libary
 void ICM20948Sensor::motionLoop() {
-
+    timer.tick();
     if(imu.dataReady())
     {
         lastReset = -1;
         lastData = millis();
-        Serial.println("IMU Data ready, timeout Reset");
+        // Serial.println("IMU Data ready, timeout Reset");
     }
     
 
@@ -456,41 +516,66 @@ void ICM20948Sensor::motionLoop() {
 }
 
 void ICM20948Sensor::sendData() { 
-    
-    Serial.println("Check if my FIFO Data Availiable");
-    Serial.print("Status is ");
-    Serial.println(imu.statusString(imu.status));
-    Serial.println("Attempt to read DMP Data");
-    Serial.print("Read Status is ");
+    // Serial.println("Check if my FIFO Data Availiable");
+    // Serial.print("Status is ");
+    // Serial.println(imu.statusString(imu.status));
+    // Serial.println("Attempt to read DMP Data");
+    // Serial.print("Read Status is ");
     ICM_20948_Status_e readStatus = imu.readDMPdataFromFIFO(&dmpData);
         if(readStatus == ICM_20948_Stat_Ok)
         {
-            Serial.println("Reading DMP Data");
-            if ((dmpData.header & DMP_header_bitmap_Quat9) > 0)
+            // Serial.println("Reading DMP Data");
+            if (USE_6_AXIS)
             {
-                Serial.println("Converting Rotation Data");
-                // Q0 value is computed from this equation: Q0^2 + Q1^2 + Q2^2 + Q3^2 = 1.
-                // In case of drift, the sum will not add to 1, therefore, quaternion data need to be corrected with right bias values.
-                // The quaternion data is scaled by 2^30.
-                // Scale to +/- 1
-                double q1 = ((double)dmpData.Quat9.Data.Q1) / 1073741824.0; // Convert to double. Divide by 2^30
-                double q2 = ((double)dmpData.Quat9.Data.Q2) / 1073741824.0; // Convert to double. Divide by 2^30
-                double q3 = ((double)dmpData.Quat9.Data.Q3) / 1073741824.0; // Convert to double. Divide by 2^30
-                double q0 = sqrt(1.0 - ((q1 * q1) + (q2 * q2) + (q3 * q3)));
-                quaternion.w = q0;
-                quaternion.x = q1;
-                quaternion.y = q2;
-                quaternion.z = q3;
-                Serial.println("Sending Rotation Data to Server");
-                sendRotationData(&quaternion, DATA_TYPE_NORMAL, dmpData.Quat9.Data.Accuracy, auxiliary, PACKET_ROTATION_DATA);
+                if ((dmpData.header & DMP_header_bitmap_Quat6) > 0)
+                {
+                    // Serial.println("Converting Rotation Data");
+                    // Q0 value is computed from this equation: Q0^2 + Q1^2 + Q2^2 + Q3^2 = 1.
+                    // In case of drift, the sum will not add to 1, therefore, quaternion data need to be corrected with right bias values.
+                    // The quaternion data is scaled by 2^30.
+                    // Scale to +/- 1
+                    double q1 = ((double)dmpData.Quat6.Data.Q1) / 1073741824.0; // Convert to double. Divide by 2^30
+                    double q2 = ((double)dmpData.Quat6.Data.Q2) / 1073741824.0; // Convert to double. Divide by 2^30
+                    double q3 = ((double)dmpData.Quat6.Data.Q3) / 1073741824.0; // Convert to double. Divide by 2^30
+                    double q0 = sqrt(1.0 - ((q1 * q1) + (q2 * q2) + (q3 * q3)));
+                    quaternion.w = q0;
+                    quaternion.x = q1;
+                    quaternion.y = q2;
+                    quaternion.z = q3;
+                    quaternion *= sensorOffset; //imu rotation
+                    // Serial.println("Sending Rotation Data to Server");
+                    sendRotationData(&quaternion, DATA_TYPE_NORMAL, 0, auxiliary, PACKET_ROTATION_DATA);
+                }
+            }
+            else
+            {
+                if ((dmpData.header & DMP_header_bitmap_Quat9) > 0)
+                {
+                    // Serial.println("Converting Rotation Data");
+                    // Q0 value is computed from this equation: Q0^2 + Q1^2 + Q2^2 + Q3^2 = 1.
+                    // In case of drift, the sum will not add to 1, therefore, quaternion data need to be corrected with right bias values.
+                    // The quaternion data is scaled by 2^30.
+                    // Scale to +/- 1
+                    double q1 = ((double)dmpData.Quat9.Data.Q1) / 1073741824.0; // Convert to double. Divide by 2^30
+                    double q2 = ((double)dmpData.Quat9.Data.Q2) / 1073741824.0; // Convert to double. Divide by 2^30
+                    double q3 = ((double)dmpData.Quat9.Data.Q3) / 1073741824.0; // Convert to double. Divide by 2^30
+                    double q0 = sqrt(1.0 - ((q1 * q1) + (q2 * q2) + (q3 * q3)));
+                    quaternion.w = q0;
+                    quaternion.x = q1;
+                    quaternion.y = q2;
+                    quaternion.z = q3;
+                    quaternion *= sensorOffset; //imu rotation
+                    // Serial.println("Sending Rotation Data to Server");
+                    sendRotationData(&quaternion, DATA_TYPE_NORMAL, dmpData.Quat9.Data.Accuracy, auxiliary, PACKET_ROTATION_DATA);
+                }
             }
         }
         else
         {
             //This may lead to instability, or not
-            Serial.print("[ERR] Failed read DMP FIFO data ");
-            Serial.println(IMU_NAME);
-            Serial.println(imu.statusString(readStatus));
+            // Serial.print("[ERR] Failed read DMP FIFO data ");
+            // Serial.println(IMU_NAME);
+            // Serial.println(imu.statusString(readStatus));
         }
 }
 
@@ -502,8 +587,9 @@ void ICM20948Sensor::startCalibration(int calibrationType) {
     //     save_bias(false);
     // #endif
     // TODO: If 8266, save the current bias values to eeprom
-    //#ifdef 8266
+    #ifdef ESP8266
     // Types are int, device config saves float - need to save and load like mpu6050 does
-    //#endif
+        save_bias(false);
+    #endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,6 +150,7 @@ void setup()
             secondImuActive = true;
         } else {
             sensor.setupICM20948(false, first);
+            secondImuActive = false; // if not found 2nd imu then false
         }
     #else
     sensor.setupICM20948(false, I2CSCAN::pickDevice(ICM_ADDR_1, ICM_ADDR_2, true));
@@ -157,10 +158,11 @@ void setup()
 #endif
 
     sensor.motionSetup();
-#ifdef HAS_SECOND_IMU
-    if(secondImuActive)
+// #ifdef HAS_SECOND_IMU
+    if(secondImuActive) {
         sensor2.motionSetup();
-#endif
+    }
+// #endif
 
     setUpWiFi();
     otaSetup(otaPassword);
@@ -171,33 +173,36 @@ void setup()
 
 void loop()
 {
-    Serial.println("Main Loop Start");
+    // too much print seems to cause it not to work properly...
+    // Serial.println("Main Loop Start");
     ledStatusUpdate();
-    Serial.println("LED Updated");
+    // Serial.println("LED Updated");
     serialCommandsUpdate();
-    Serial.println("Commands Updated");
+    // Serial.println("Commands Updated");
     wifiUpkeep();
-    Serial.println("Wifi upkeep");
+    // Serial.println("Wifi upkeep");
     otaUpdate();
-    Serial.println("OTA Updated");
+    //Serial.println("OTA Updated");
     clientUpdate(&sensor, &sensor2);
-    Serial.println("Client Updated");
+    // Serial.println("Client Updated");
     if (isCalibrating)
     {
-        Serial.println("Started Calibration");
+        // Serial.println("Started Calibration");
         sensor.startCalibration(0);
         //sensor2.startCalibration(0);
         isCalibrating = false;
-        Serial.println("Finished Calibration");
+        // Serial.println("Finished Calibration");
     }
 #ifndef UPDATE_IMU_UNCONNECTED
         if(isConnected()) {
 #endif
     sensor.motionLoop();
-#ifdef HAS_SECOND_IMU
-    sensor2.motionLoop();
-#endif
-Serial.println("Motion loops Completed");
+// #ifdef HAS_SECOND_IMU
+    if (secondImuActive) {
+        sensor2.motionLoop();
+    }
+// #endif
+// Serial.println("Motion loops Completed");
 #ifndef UPDATE_IMU_UNCONNECTED
         }
 #endif
@@ -206,14 +211,16 @@ Serial.println("Motion loops Completed");
 #ifndef SEND_UPDATES_UNCONNECTED
     if(isConnected()) {
 #endif
-        Serial.println("Send Data Sensor 1 Start");
-        sensor.sendData();
-        Serial.println("Send Data Sensor 1 Completed");
-#ifdef HAS_SECOND_IMU
-        Serial.println("Send Data Sensor 2 Start");
+    // Serial.println("Send Data Sensor 1 Start");
+    sensor.sendData();
+    // Serial.println("Send Data Sensor 1 Completed");
+// #ifdef HAS_SECOND_IMU
+    if (secondImuActive) {
+        // Serial.println("Send Data Sensor 2 Start");
         sensor2.sendData();
-        Serial.println("Send Data Sensor 2 Completed");
-#endif
+        // Serial.println("Send Data Sensor 2 Completed");
+    }
+//#endif
 #ifndef SEND_UPDATES_UNCONNECTED
     }
 #endif

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -33,6 +33,7 @@
 #include "configuration.h"
 #include <Adafruit_BNO055.h>
 #include "defines.h"
+#include <arduino-timer.h> // Used for periodically saving bias
 
 
 #define DATA_TYPE_NORMAL 1
@@ -180,8 +181,9 @@ private:
     void i2c_scan();
     bool auxiliary{ false };
     unsigned long lastData = 0;
+    uint8_t first_imu;
+    uint8_t second_imu;
     uint8_t addr = 0x69;
-    uint8_t ad0_Val = 1;
     int bias_save_counter = 0;
     uint8_t ICM_address;
     bool ICM_found = false;
@@ -194,6 +196,9 @@ private:
     icm_20948_DMP_data_t dmpData {};
 #ifdef ESP32
     Preferences prefs;
+    Timer<> timer = timer_create_default();
+#endif
+#ifdef ESP8266
     Timer<> timer = timer_create_default();
 #endif
     //TapDetector tapDetector;


### PR DESCRIPTION
Add support for 6-axis
Use EEPROM to save the current bias values
Single IMU tracker can run whether AD0 is 0x68 or 0x69
Support two IMU's
Boost ODR rate to 112hz, about 130tps (MAX 225hz)
Reset external libraries, not modify them
Disable other DMPSensor to test, maybe they are not needed

Tested and passed in TTGO T-OI ESP8266 + GY912