### PR TITLE
If AD0 of the 1st IMU is 0x68, That must be a single IMU tracker, else invert `auxiliary` value

### DIFF
--- a/src/icm20948sensor.cpp
+++ b/src/icm20948sensor.cpp
@@ -152,12 +152,8 @@ void ICM20948Sensor::motionSetup() {
     #ifdef FULL_DEBUG
         imu.enableDebugging(Serial);
     #endif
-    if (first_imu == 0x68) {
-        // Just in case the 1st IMU AD0 is 0x68
-        #define ICM_20948_I2C_ADDR_AD0 = 0x69
-        #define ICM_20948_I2C_ADDR_AD1 = 0x68
-    }
-    if (imu.begin(Wire, auxiliary) != ICM_20948_Stat_Ok) {
+    // Just in case the 1st IMU AD0 is 0x68
+    if (imu.begin(Wire, ((auxiliary == false && first_imu == 0x68) ? 0 : !auxiliary )) != ICM_20948_Stat_Ok) {
         Serial.print("[ERR] IMU ICM20948: Can't connect to ");
         Serial.println(IMU_NAME);
         signalAssert();
@@ -650,8 +646,8 @@ ICM_20948_Status_e ICM_20948::initializeDMP(void)
   // Set gyro sample rate divider with GYRO_SMPLRT_DIV
   // Set accel sample rate divider with ACCEL_SMPLRT_DIV_2
   ICM_20948_smplrt_t mySmplrt;
-  mySmplrt.g = 19; // ODR is computed as follows: 1.1 kHz/(1+GYRO_SMPLRT_DIV[7:0]). 19 = 55Hz. InvenSense Nucleo example uses 19 (0x13).
-  mySmplrt.a = 19; // ODR is computed as follows: 1.125 kHz/(1+ACCEL_SMPLRT_DIV[11:0]). 19 = 56.25Hz. InvenSense Nucleo example uses 19 (0x13).
+  mySmplrt.g = 4; // ODR is computed as follows: 1.1 kHz/(1+GYRO_SMPLRT_DIV[7:0]). 19 = 55Hz. InvenSense Nucleo example uses 19 (0x13).
+  mySmplrt.a = 4; // ODR is computed as follows: 1.125 kHz/(1+ACCEL_SMPLRT_DIV[11:0]). 19 = 56.25Hz. InvenSense Nucleo example uses 19 (0x13).
   //mySmplrt.g = 4; // 225Hz
   //mySmplrt.a = 4; // 225Hz
   //mySmplrt.g = 8; // 112Hz
@@ -726,7 +722,7 @@ ICM_20948_Status_e ICM_20948::initializeDMP(void)
   //            0=1125Hz sample rate, 1=562.5Hz sample rate, ... 4=225Hz sample rate, ...
   //            10=102.2727Hz sample rate, ... etc.
   // @param[in] gyro_level 0=250 dps, 1=500 dps, 2=1000 dps, 3=2000 dps
-  result = setGyroSF(19, 3); if (result > worstResult) worstResult = result; // 19 = 55Hz (see above), 3 = 2000dps (see above)
+  result = setGyroSF(4, 3); if (result > worstResult) worstResult = result; // 19 = 55Hz (see above), 3 = 2000dps (see above)
 
   // Configure the Gyro full scale
   // 2000dps : 2^28

--- a/src/icm20948sensor.cpp
+++ b/src/icm20948sensor.cpp
@@ -152,7 +152,12 @@ void ICM20948Sensor::motionSetup() {
     #ifdef FULL_DEBUG
         imu.enableDebugging(Serial);
     #endif
-    if (imu.begin(Wire, addr) != ICM_20948_Stat_Ok) {
+    if (first_imu == 0x68) {
+        // Just in case the 1st IMU AD0 is 0x68
+        #define ICM_20948_I2C_ADDR_AD0 = 0x69
+        #define ICM_20948_I2C_ADDR_AD1 = 0x68
+    }
+    if (imu.begin(Wire, auxiliary) != ICM_20948_Stat_Ok) {
         Serial.print("[ERR] IMU ICM20948: Can't connect to ");
         Serial.println(IMU_NAME);
         signalAssert();


### PR DESCRIPTION
Because the 1st AD0 of the two IMU's tracker must be 0x69